### PR TITLE
MkDocs integration with GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+---
+name: main
+
+on:
+  push: # All branches and tags
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  job:
+    permissions: { id-token: write, pages: write }
+    uses: dmotte/misc/.github/workflows/cicd-with-script.yml@main
+    with:
+      script: >
+        MKDOCS_DEPS=mkdocs-material,mkdocs-minify-plugin,pymdown-extensions
+        MKDOCS_DOCS_SRC=. MKDOCS_DOCS_DST=mkdocs-docs
+        MKDOCS_DOCS_EXCLUDES=.git,venv,mkdocs-docs,mkdocs-site
+        MKDOCS_SITE_DIR=mkdocs-site
+        bash "$(realpath "$GITHUB_ACTION_PATH/../../scripts/cicd/mkdocs-ghpages.sh")"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ jobs:
     permissions: { id-token: write, pages: write }
     uses: dmotte/misc/.github/workflows/cicd-with-script.yml@main
     with:
+      # These would be overkill here
+      run-shellcheck: false
+      run-trivy: false
+
       script: >
         MKDOCS_DEPS=mkdocs-material,mkdocs-minify-plugin,pymdown-extensions
         MKDOCS_DOCS_SRC=. MKDOCS_DOCS_DST=mkdocs-docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/venv/
+/mkdocs-docs/
+/mkdocs-site/

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,0 @@
----
-theme: jekyll-theme-cayman

--- a/dev/php/xdebug-settings.md
+++ b/dev/php/xdebug-settings.md
@@ -59,9 +59,9 @@ xdebug.remote_autostart = 1
         // customize
         "max_children": 128,
         "max_data": 512,
-        "max_depth": 6
-      }
-    }
-  ]
+        "max_depth": 6,
+      },
+    },
+  ],
 }
 ```

--- a/devops/svn.md
+++ b/devops/svn.md
@@ -20,9 +20,9 @@ This can be used, for example, to fix a broken repo.
 
 In the example below, `r385` of repo `my-repo` will be used.
 
-> <https://superuser.com/a/315138>
-> <https://svnbook.red-bean.com/en/1.7/svn.ref.svnadmin.html>
-> <https://www.saas-secure.com/svn-hosting/svn-dump-restore.html>
+> - https://superuser.com/a/315138
+> - https://svnbook.red-bean.com/en/1.7/svn.ref.svnadmin.html
+> - https://www.saas-secure.com/svn-hosting/svn-dump-restore.html
 
 #### 1. create new repo
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,73 @@
+---
+strict: true
+docs_dir: !ENV MKDOCS_DOCS_DST
+site_dir: !ENV MKDOCS_SITE_DIR
+
+# Inspired by https://github.com/dmotte/misc/blob/main/mkdocs.yml
+
+site_name: KnowledgeBass
+site_url: https://violinminds.github.io/knowledgebass/
+site_author: violinminds
+site_description: Errare humanvm est, perseverare is like breadcrumbs on top of pasta.
+
+repo_name: violinminds/knowledgebass
+repo_url: https://github.com/violinminds/knowledgebass
+edit_uri: blob/main
+
+theme:
+  name: material
+  features:
+    - content.action.edit
+    - content.action.view
+    - content.code.copy
+    - content.tooltips
+    - navigation.tabs
+    - navigation.indexes # Provides same behavior as the "mkdocs-section-index" plugin
+    - navigation.expand
+    - navigation.footer
+    - navigation.top
+    - search.share
+    - search.suggest
+    - search.highlight
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/link
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: indigo
+      toggle:
+        icon: material/toggle-switch-off
+        name: Switch to system preference
+  # favicon: null
+  icon: { logo: material/music-clef-bass }
+
+plugins:
+  - minify: { minify_html: true }
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/violinminds
+
+markdown_extensions:
+  - pymdownx.magiclink
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      auto_title: true
+      auto_title_map: { Text Only: "" }
+      linenums: true
+      anchor_linenums: true
+  - pymdownx.superfences

--- a/sysadmin/ms-sqlserver.md
+++ b/sysadmin/ms-sqlserver.md
@@ -54,11 +54,11 @@ This is a quick guide on how to allow other database management tools (eg. [DBea
 5. **stop** and **start** SQL Server and SQL Server Browser services
 6. connect with these credentials
 
-  ```text
-    host 127.0.0.1\SQLEXPRESS
-    port 1433
-    user sa
-    pass <selected password>
-  ```
+```text
+  host 127.0.0.1\SQLEXPRESS
+  port 1433
+  user sa
+  pass <selected password>
+```
 
 Please note: server name `127.0.0.1\SQLEXPRESS` should be what you see in SQL Server Management Studio's object explorer and will probably vary depending on the server version.

--- a/sysadmin/win-openssh.md
+++ b/sysadmin/win-openssh.md
@@ -219,6 +219,7 @@ Banner c:\banner_to_show_when_sshing_-T.txt
 - if you get the warning "@ WARNING: UNPROTECTED PRIVATE KEY FILE! @" when trying to use the keys, fix the private key(s) file(s) permissions to allow FULL CONTROL to the current user, `SYSTEM` and the `Administrators` group
 - if a repository was already cloned via HTTPS and you want to start working via SSH, change its remote via: `git remote set-url origin git@github.com:violinminds/knowledgebass.git`. To verify the current remotes, run: `git remote -v`
 - if you get an error, eg. "Permission denied (publickey). fatal: Could not read from remote repository.", to debug, you can add the `-v` switch to `core.sshCommand` setting in the git config to be more verbose (use `-vvv` to be even more verbose)
+
   - a possible problem might be that, for some reason, ssh is not using the agent's keys. In the verbose debug log, ssh reports a list of the keys it tries to use when connecting to an ssh host, which should also include the agent's keys. If the agent keys are missing, see the following Troubleshooting tips. Example of correct debug log:
 
   ```ini

--- a/sysadmin/win-rdp.md
+++ b/sysadmin/win-rdp.md
@@ -1,5 +1,5 @@
 # Remote Desktop Connection on Windows
->
+
 > tags: mstsc, rdp
 
 ## Basic setup

--- a/sysadmin/win-start.md
+++ b/sysadmin/win-start.md
@@ -38,7 +38,7 @@ For more information run: `get-help about_Command_Precedence`
 
 > When the [ShellExecuteEx](https://learn.microsoft.com/en-us/windows/desktop/api/Shellapi/nf-shellapi-shellexecuteexa) function is called with the name of an executable file in its _lpFile_ parameter, there are several places where the function looks for the file. We recommend registering your application in the **App Paths** registry subkey. Doing so avoids the need for applications to modify the system PATH environment variable.
 >
-> - The file is sought in the following locations:
+> The file is sought in the following locations:
 >
 > - The current working directory.
 > - The **Windows** directory only (no subdirectories are searched).


### PR DESCRIPTION
I recently set up **MkDocs** integration with **GitHub Pages** on [a repository of mine](https://github.com/dmotte/misc): basically I wrote a script to run MkDocs inside **GitHub Actions**, that automatically generates a proper (**static**) **website** that is well-organized, searchable, etc. and uses the [**Material for MkDocs**](https://squidfunk.github.io/mkdocs-material/) theme.

So I thought it would be nice to configure _KnowledgeBass_ in a similar way to get the same result. I got something that looks like this:

![screen01](https://github.com/violinminds/knowledgebass/assets/37443982/f591b935-2315-494c-949b-7a6adea8e89e)
![screen02](https://github.com/violinminds/knowledgebass/assets/37443982/28c8e678-3c38-4c2c-a175-dfb9f4b4ef41)

If you want to give it a try locally before approving this PR, you can download the generated zip file from the **Artifacts** section of the latest _GitHub Actions_ workflow run (at the moment this one: https://github.com/violinminds/knowledgebass/actions/runs/8590462276). There is only one artifact, named `github-pages`.

In this PR I'm providing some basic configuration (mostly based on mine), but, if you like this idea, feel free to customize the config files as you wish 🙂 

---

**Note**: to make this work, we have to set the GitHub Pages **source** to "GitHub Actions" in the [repo settings](https://github.com/violinminds/knowledgebass/settings/pages) before merging this PR, like this:

![screen-repo-settings](https://github.com/violinminds/knowledgebass/assets/37443982/721a3497-d546-4f19-9d54-42243c34bce6)
